### PR TITLE
Use BlockEntity types in the CropRegistry instead of BlockEntities

### DIFF
--- a/Common/src/main/java/com/t2pellet/strawgolem/crop/CropRegistry.java
+++ b/Common/src/main/java/com/t2pellet/strawgolem/crop/CropRegistry.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.AABB;
@@ -42,7 +43,7 @@ public interface CropRegistry {
      *
      * @param id the block to register
      */
-    <T extends BlockEntity> void register(T id, IHarvestChecker<T> harvestChecker, IHarvestLogic<T> harvestLogic, IReplantLogic<T> replantLogic);
+    <T extends BlockEntity> void register(BlockEntityType<T> id, IHarvestChecker<T> harvestChecker, IHarvestLogic<T> harvestLogic, IReplantLogic<T> replantLogic);
 
     /**
      * Determine if crop is grown


### PR DESCRIPTION
This is because BlockEntities are volatile objects, so one would need to register a BlockEntity every time it is created, causing a massive memory leak. 
Instead, it is better to define them based on the BlockEntityType, which is a registered single instance.

I have also taken the liberty to not query the BlockEntity from the world every time, as this can be quite an expensive operation.

(Edit to mention that this PR goes in conjunction with #76 )