### PR TITLE
Add support for modded bushes to work in Forge 1.16 version

### DIFF
--- a/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHelper.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/config/ConfigHelper.java
@@ -78,7 +78,7 @@ public class ConfigHelper {
 
             case StrawgolemConfig.FILTER_MODE_BLACKLIST:
                 // prioritise blacklist
-                StrawgolemConfig.FilterMatch blacklistMatch = blockMatchesFilter(block, StrawgolemConfig.whitelist);
+                StrawgolemConfig.FilterMatch blacklistMatch = blockMatchesFilter(block, StrawgolemConfig.blacklist);
                 // if we got a blacklist match by mod, check if we're whitelisted by item
                 if (blacklistMatch == StrawgolemConfig.FilterMatch.Mod)
                     return blockMatchesFilter(block, StrawgolemConfig.whitelist) == StrawgolemConfig.FilterMatch.Exact;

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/EntityStrawGolem.java
@@ -309,9 +309,17 @@ public class EntityStrawGolem extends GolemEntity {
                 return true;
             else if (state.getBlock() instanceof NetherWartBlock)
                 return state.get(NetherWartBlock.AGE) == 3;
-            else if (state.getBlock() instanceof BushBlock && state.getBlock() instanceof IGrowable)
-                return state.func_235901_b_(BlockStateProperties.AGE_0_3)
-                        && state.get(BlockStateProperties.AGE_0_3) == 3;
+            else if (state.getBlock() instanceof BushBlock && state.getBlock() instanceof IGrowable) {
+                if (state.func_235901_b_(BlockStateProperties.AGE_0_2)) {
+                    return state.get(BlockStateProperties.AGE_0_2) == 2;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_3)) {
+                    return state.get(BlockStateProperties.AGE_0_3) == 3;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_5)) {
+                    return state.get(BlockStateProperties.AGE_0_5) == 5;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_7)) {
+                    return state.get(BlockStateProperties.AGE_0_7) == 7;
+                }
+            }
         }
         return false;
     }

--- a/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemHarvestGoal.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/entity/ai/GolemHarvestGoal.java
@@ -107,6 +107,9 @@ public class GolemHarvestGoal extends MoveToBlockGoal {
         if (shouldMoveTo(worldIn, pos)) {
             worldIn.playSound(null, pos, SoundEvents.BLOCK_CROP_BREAK, SoundCategory.BLOCKS, 1.0F, 1.0F);
             doPickup(worldIn, pos, state, block);
+            /* Update new block state, if changed in doPickup() */
+            state = worldIn.getBlockState(pos);
+            block = state.getBlock();
             doReplant(worldIn, pos, state, block);
         }
     }
@@ -152,8 +155,16 @@ public class GolemHarvestGoal extends MoveToBlockGoal {
                 worldIn.setBlockState(pos, crop.getDefaultState());
             } else if (block instanceof NetherWartBlock) {
                 worldIn.setBlockState(pos, block.getDefaultState().with(NetherWartBlock.AGE, 0));
-            } else if (state.func_235901_b_(BlockStateProperties.AGE_0_3) && block instanceof BushBlock) { // Bushes
-                worldIn.setBlockState(pos, block.getDefaultState().with(BlockStateProperties.AGE_0_3, 2));
+            } else if (block instanceof BushBlock) { // Bushes
+                if (state.func_235901_b_(BlockStateProperties.AGE_0_2) && state.get(BlockStateProperties.AGE_0_2) == 2) {
+                    worldIn.setBlockState(pos, Blocks.AIR.getDefaultState());
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_3) && state.get(BlockStateProperties.AGE_0_3) == 3) {
+                    worldIn.setBlockState(pos, Blocks.AIR.getDefaultState());
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_5) && state.get(BlockStateProperties.AGE_0_5) == 5) {
+                    worldIn.setBlockState(pos, Blocks.AIR.getDefaultState());
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_7) && state.get(BlockStateProperties.AGE_0_7) == 7) {
+                    worldIn.setBlockState(pos, Blocks.AIR.getDefaultState());
+                } // else Don't change block state, doPickup() / fakePlayerClick() has already handled it
             } else {
                 worldIn.setBlockState(pos, Blocks.AIR.getDefaultState());
             }

--- a/src/main/java/com/commodorethrawn/strawgolem/events/CropGrowthHandler.java
+++ b/src/main/java/com/commodorethrawn/strawgolem/events/CropGrowthHandler.java
@@ -131,9 +131,16 @@ public class CropGrowthHandler {
             } else if (state.getBlock() instanceof NetherWartBlock) {
                 return state.get(NetherWartBlock.AGE) == 3;
             } else if (state.getBlock() instanceof BushBlock
-                    && state.getBlock() instanceof IGrowable
-                    && state.func_235901_b_(BlockStateProperties.AGE_0_3)) {
-                return state.get(BlockStateProperties.AGE_0_3) == 3;
+                    && state.getBlock() instanceof IGrowable) {
+                if (state.func_235901_b_(BlockStateProperties.AGE_0_2)) {
+                    return state.get(BlockStateProperties.AGE_0_2) == 2;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_3)) {
+                    return state.get(BlockStateProperties.AGE_0_3) == 3;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_5)) {
+                    return state.get(BlockStateProperties.AGE_0_5) == 5;
+                } else if (state.func_235901_b_(BlockStateProperties.AGE_0_3)) {
+                    return state.get(BlockStateProperties.AGE_0_7) == 7;
+                }
             }
         }
         return false;


### PR DESCRIPTION
This would fix mod compatibility issues for most modded crops instanced from `BushBlock` for Forge 1.16 version, as mentioned in #10, such as Farmer's Delight Tomatoes (which uses `AGE_0_7`).

The _master_ branch with the rewritten logic has already fixed this, but not in the older versions like `forge-1.16`.